### PR TITLE
nepc and nepc-test database on Windows WSL2

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,7 +9,7 @@ dependencies:
         - jupyter_client
         - numpy
         - pandas
-        - python
+        - python==3.7
         - matplotlib
         - tabulate
         - pytest


### PR DESCRIPTION
MySQL connector broken with python 3.8, so specify python==3.7 in nepc-dev conda env.