### PR TITLE
Moved reaction_test and reaction_latex inside CS

### DIFF
--- a/nepc/__init__.py
+++ b/nepc/__init__.py
@@ -7,9 +7,6 @@ from .nepc import cs_sigma
 from .nepc import cs_metadata
 from .nepc import table_as_df
 from .nepc import process_attr
-from .nepc import reaction_latex
-from .nepc import reaction_text_side
-from .nepc import reaction_text
 from .nepc import CS
 from .nepc import CustomCS
 from .nepc import Model
@@ -28,9 +25,6 @@ __all__ = [
         'cs_metadata',
         'table_as_df',
         'process_attr',
-        'reaction_latex',
-        'reaction_text_side',
-        'reaction_text',
         'CS',
         'CustomCS',
         'Model',

--- a/nepc/nepc.py
+++ b/nepc/nepc.py
@@ -414,7 +414,6 @@ class CS:
             The plain text for either the LHS or RHS of the process involved in a NEPC cross section
             (LaTeX) formatted if indicated.
         """
-        # FIXME: move this method to the CS Class
         # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
         # FIXME: decide how to represent total cross sections and implement
 
@@ -473,7 +472,6 @@ class CS:
         : (str, str)
             The plain text (abbrev, full) for the process involved in a NEPC cross section.
         """
-        # FIXME: move this method to the CS Class
         # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
         # FIXME: decide how to represent total cross sections and implement
         lhs_text_abbrev, lhs_text_full = self.reaction_text_side('LHS')
@@ -493,7 +491,6 @@ class CS:
         : str
             The LaTeX for the process involved in a NEPC cross section.
         """
-        # FIXME: move this method to the CS Class
         # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
         # FIXME: decide how to represent total cross sections and implement
         lhs_text = self.reaction_text_side('LHS', latex=True)

--- a/nepc/nepc.py
+++ b/nepc/nepc.py
@@ -417,27 +417,23 @@ class CS:
         # FIXME: move this method to the CS Class
         # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
         # FIXME: decide how to represent total cross sections and implement
-        
+
+        keys = {'LHS': {'e': 'e_on_lhs',
+                        'sideA': 'lhsA',
+                        'sideB': 'lhsB',
+                        'side_v': 'lhs_v'},
+                'RHS': {'e': 'e_on_rhs',
+                        'sideA': 'rhsA',
+                        'sideB': 'rhsB',
+                        'side_v': 'rhs_v'}
+                }
+
         if latex: 
-            keys = {'LHS': {'e': 'e_on_lhs',
-                            'sideA': 'lhsA_long',
-                            'sideB': 'lhsB_long',
-                            'side_v': 'lhs_v'},
-                    'RHS': {'e': 'e_on_rhs',
-                            'sideA': 'rhsA_long',
-                            'sideB': 'rhsB_long',
-                            'side_v': 'rhs_v'}
-                    }
-        else: 
-            keys = {'LHS': {'e': 'e_on_lhs',
-                            'sideA': 'lhsA',
-                            'sideB': 'lhsB',
-                            'side_v': 'lhs_v'},
-                    'RHS': {'e': 'e_on_rhs',
-                            'sideA': 'rhsA',
-                            'sideB': 'rhsB',
-                            'side_v': 'rhs_v'}
-                    }
+            keys['LHS']['sideA'] = 'lhsA_long'
+            keys['LHS']['sideB'] = 'lhsB_long'
+            keys['RHS']['sideA'] = 'rhsA_long'
+            keys['RHS']['sideB'] = 'rhsB_long'
+
         self.e_on_side = self.metadata[keys[side]['e']]
 
         if self.e_on_side == 0:

--- a/nepc/nepc.py
+++ b/nepc/nepc.py
@@ -47,6 +47,16 @@ from nepc.util import config
 
 PRODUCTION = config.production()
 
+def lazy_property(fn):
+    attr = "_lazy_" + fn.__name__
+
+    @property
+    def _lazy_property(self):
+        if not hasattr(self, attr):
+            setattr(self, attr, fn(self))
+        return getattr(self, attr)
+
+    return _lazy_property
 
 def connect(local=False, DBUG=False, test=False, travis=False):
     """Establish a connection to a NEPC MySQL database
@@ -460,7 +470,7 @@ class CS:
         self.side_text_abbrev = " + ".join(item for item in self.side_items_abbrev if item)
         return self.side_text_abbrev, self.side_text_full
 
-
+    @lazy_property
     def reaction_text(self):
         """Return the plain text for the process involved in a nepc cross section.
         Parameters
@@ -480,6 +490,7 @@ class CS:
         self.reaction_full = " -> ".join([lhs_text_full, rhs_text_full])
         return self.reaction_abbrev, self.reaction_full
 
+    @lazy_property
     def reaction_latex(self):
         """Return the LaTeX for the process involved in a nepc cross section.
         Parameters
@@ -771,7 +782,7 @@ class Model:
                 max_peak_sigma = cs_peak_sigma
             if cs_peak_sigma < min_peak_sigma:
                 min_peak_sigma = cs_peak_sigma
-            reaction = cs.reaction_latex()
+            reaction = cs.reaction_latex
             cs_lpu = cs.metadata["lpu"]
             cs_upu = cs.metadata["upu"]
             if cs_lpu is not None and cs_lpu > max_lpu:

--- a/nepc/nepc.py
+++ b/nepc/nepc.py
@@ -453,13 +453,14 @@ class CS:
                                 self.sideB_text]
         self.side_text_full = " + ".join(item for item in self.side_items_full if item)
 
-        if not latex: 
-            self.side_items_abbrev = [self.sideA_text,
-                                      self.sideB_text]
-            self.side_text_abbrev = " + ".join(item for item in self.side_items_abbrev if item)
-            return self.side_text_abbrev, self.side_text_full
+        if latex: 
+            return self.side_text_full
+        
+        self.side_items_abbrev = [self.sideA_text,
+                                  self.sideB_text]
+        self.side_text_abbrev = " + ".join(item for item in self.side_items_abbrev if item)
+        return self.side_text_abbrev, self.side_text_full
 
-        return self.side_text_full
 
     def reaction_text(self):
         """Return the plain text for the process involved in a nepc cross section.

--- a/nepc/nepc.py
+++ b/nepc/nepc.py
@@ -400,56 +400,70 @@ class CS:
         r"""The number of data points in the cross section data set"""
         return len(self.data['e'])
 
-    def reaction_text_side(self, side):
-        """Return the plain text for the LHS or RHS of the process involved in a nepc cross section.
+    def reaction_text_side(self, side, latex=False):
+        """Return the LaTeX for the LHS of the process involved in a nepc cross section.
         Parameters
         ----------
         side : str
             'LHS' or 'RHS' to indicate which side of the reaction to return.
-        cs : :class:`.CS` or :class:`.CustomCS`
-            A nepc cross section.
+        latex : bool, default False
+            Determine whether or not to output the LaTeX formatted text. 
         Returns
         -------
         : str
-            The plain text for either the LHS or RHS of the process involved in a NEPC cross section.
+            The plain text for either the LHS or RHS of the process involved in a NEPC cross section
+            (LaTeX) formatted if indicated.
         """
         # FIXME: move this method to the CS Class
         # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
         # FIXME: decide how to represent total cross sections and implement
-        keys = {'LHS': {'e': 'e_on_lhs',
-                        'sideA': 'lhsA',
-                        'sideB': 'lhsB',
-                        'side_v': 'lhs_v'},
-                'RHS': {'e': 'e_on_rhs',
-                        'sideA': 'rhsA',
-                        'sideB': 'rhsB',
-                        'side_v': 'rhs_v'}
-                }
-
+        
+        if latex: 
+            keys = {'LHS': {'e': 'e_on_lhs',
+                            'sideA': 'lhsA_long',
+                            'sideB': 'lhsB_long',
+                            'side_v': 'lhs_v'},
+                    'RHS': {'e': 'e_on_rhs',
+                            'sideA': 'rhsA_long',
+                            'sideB': 'rhsB_long',
+                            'side_v': 'rhs_v'}
+                    }
+        else: 
+            keys = {'LHS': {'e': 'e_on_lhs',
+                            'sideA': 'lhsA',
+                            'sideB': 'lhsB',
+                            'side_v': 'lhs_v'},
+                    'RHS': {'e': 'e_on_rhs',
+                            'sideA': 'rhsA',
+                            'sideB': 'rhsB',
+                            'side_v': 'rhs_v'}
+                    }
         self.e_on_side = self.metadata[keys[side]['e']]
 
         if self.e_on_side == 0:
-            self.side_e_text = None
+            self.side_e_text= None
         elif self.e_on_side == 1:
-            self.side_e_text = "E"
-            # self.side_e_text = "e$^-$" Latex version
+            self.side_e_text = "e$^-$" if latex else "E"
         else:
-            self.side_e_text = str(self.e_on_side) + "E"
-            # self.side_e_text = str(self.e_on_side) + "e$^-$" Latex version
+            self.side_e_text = str(self.e_on_side) + ("e$^-$" if latex else "E")
 
         self.sideA_text = self.metadata[keys[side]['sideA']]
         if self.metadata['process'] == 'excitation_v':
             # TODO: modify for all interesting process types (e.g. excitation_j)
             self.sideA_text = self.sideA_text.replace(")", " v=" + str(self.metadata[keys[side]['side_v']]) + ")")
         self.sideB_text = self.metadata[keys[side]['sideB']]
-        self.side_items_abbrev = [self.sideA_text,
-                                  self.sideB_text]
         self.side_items_full = [self.side_e_text,
                                 self.sideA_text,
                                 self.sideB_text]
-        self.side_text_abbrev = " + ".join(item for item in self.side_items_abbrev if item)
         self.side_text_full = " + ".join(item for item in self.side_items_full if item)
-        return self.side_text_abbrev, self.side_text_full
+
+        if not latex: 
+            self.side_items_abbrev = [self.sideA_text,
+                                      self.sideB_text]
+            self.side_text_abbrev = " + ".join(item for item in self.side_items_abbrev if item)
+            return self.side_text_abbrev, self.side_text_full
+
+        return self.side_text_full
 
     def reaction_text(self):
         """Return the plain text for the process involved in a nepc cross section.
@@ -470,49 +484,6 @@ class CS:
         self.reaction_abbrev = " -> ".join([lhs_text_abbrev, rhs_text_abbrev])
         self.reaction_full = " -> ".join([lhs_text_full, rhs_text_full])
         return self.reaction_abbrev, self.reaction_full
-    
-    def reaction_latex_side(self, side):
-        """Return the LaTeX for the LHS of the process involved in a nepc cross section.
-        Parameters
-        ----------
-        side : str
-            'LHS' or 'RHS' to indicate which side of the reaction to return.
-        Returns
-        -------
-        : str
-            The LaTeX for the LHS of the process involved in a NEPC cross section.
-        """
-        # FIXME: move this method to the CS Class
-        # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
-        # FIXME: decide how to represent total cross sections and implement
-        keys = {'LHS': {'e': 'e_on_lhs',
-                        'sideA': 'lhsA_long',
-                        'sideB': 'lhsB_long',
-                        'side_v': 'lhs_v'},
-                'RHS': {'e': 'e_on_rhs',
-                        'sideA': 'rhsA_long',
-                        'sideB': 'rhsB_long',
-                        'side_v': 'rhs_v'}
-                }
-        self.e_on_side = self.metadata[keys[side]['e']]
-        # e_on_lhs = self.metadata['e_on_lhs']
-        if self.e_on_side == 0:
-            self.side_e_text= None
-        elif self.e_on_side == 1:
-            self.side_e_text = "e$^-$"
-        else:
-            self.side_e_text = str(self.e_on_side) + "e$^-$"
-
-        self.sideA_text = self.metadata[keys[side]['sideA']]
-        if self.metadata['process'] == 'excitation_v':
-            self.sideA_text = self.sideA_text.replace(")", " v=" + str(self.metadata[keys[side]['side_v']]) + ")")
-        self.sideB_text = self.metadata[keys[side]['sideB']]
-        self.side_items_full = [self.side_e_text,
-                                self.sideA_text,
-                                self.sideB_text]
-        self.side_text_full = " + ".join(item for item in self.side_items_full if item)
-
-        return self.side_text_full
 
     def reaction_latex(self):
         """Return the LaTeX for the process involved in a nepc cross section.
@@ -528,8 +499,8 @@ class CS:
         # FIXME: move this method to the CS Class
         # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
         # FIXME: decide how to represent total cross sections and implement
-        lhs_text = self.reaction_latex_side('LHS')
-        rhs_text = self.reaction_latex_side('RHS')
+        lhs_text = self.reaction_text_side('LHS', latex=True)
+        rhs_text = self.reaction_text_side('RHS', latex=True)
         reaction = " $\\rightarrow$ ".join([lhs_text, rhs_text])
         return reaction
 

--- a/nepc/nepc.py
+++ b/nepc/nepc.py
@@ -273,14 +273,12 @@ def cs_metadata(cursor, cs_id):
 class CS:
     r"""A cross section data set, including metadata and cross section data,
     from a NEPC MySQL database.
-
     Parameters
     ----------
     cursor : cursor.MySQLCursor
         A MySQLCursor object. See return value ``cursor`` of :func:`.connect`.
     cs_id : int
         i.d. of the cross section in `cs` and `csdata` tables
-
     Attributes
     ----------
     metadata : dict
@@ -348,7 +346,6 @@ class CS:
             Electron energies in units of ``units_e`` eV (see :attr:`.CS.metadata`).
         sigma : list of float
             Cross sections in units of ``units_sigma`` :math:`m^2` (see :attr:`.CS.metadata`).
-
     """
     def __init__(self, cursor, cs_id):
         metadata = cs_metadata(cursor, cs_id)
@@ -387,11 +384,154 @@ class CS:
         self.data = {"e": e_energy,
                      "sigma": sigma}
 
+        # Attributes to share
+        self.e_on_side = None
+        self.side_e_text = None
+        self.sideA_text = None
+        self.sideB_text = None
+        self.side_items_abbrev = None
+        self.side_items_full = None
+        self.side_text_abbrev = None
+        self.side_text_full = None
+        self.reaction_abbrev = None
+        self.reaction_full = None
 
     def __len__(self):
         r"""The number of data points in the cross section data set"""
         return len(self.data['e'])
 
+    def reaction_text_side(self, side):
+        """Return the plain text for the LHS or RHS of the process involved in a nepc cross section.
+        Parameters
+        ----------
+        side : str
+            'LHS' or 'RHS' to indicate which side of the reaction to return.
+        cs : :class:`.CS` or :class:`.CustomCS`
+            A nepc cross section.
+        Returns
+        -------
+        : str
+            The plain text for either the LHS or RHS of the process involved in a NEPC cross section.
+        """
+        # FIXME: move this method to the CS Class
+        # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
+        # FIXME: decide how to represent total cross sections and implement
+        keys = {'LHS': {'e': 'e_on_lhs',
+                        'sideA': 'lhsA',
+                        'sideB': 'lhsB',
+                        'side_v': 'lhs_v'},
+                'RHS': {'e': 'e_on_rhs',
+                        'sideA': 'rhsA',
+                        'sideB': 'rhsB',
+                        'side_v': 'rhs_v'}
+                }
+
+        self.e_on_side = self.metadata[keys[side]['e']]
+
+        if self.e_on_side == 0:
+            self.side_e_text = None
+        elif self.e_on_side == 1:
+            self.side_e_text = "E"
+            # self.side_e_text = "e$^-$" Latex version
+        else:
+            self.side_e_text = str(self.e_on_side) + "E"
+            # self.side_e_text = str(self.e_on_side) + "e$^-$" Latex version
+
+        self.sideA_text = self.metadata[keys[side]['sideA']]
+        if self.metadata['process'] == 'excitation_v':
+            # TODO: modify for all interesting process types (e.g. excitation_j)
+            self.sideA_text = self.sideA_text.replace(")", " v=" + str(self.metadata[keys[side]['side_v']]) + ")")
+        self.sideB_text = self.metadata[keys[side]['sideB']]
+        self.side_items_abbrev = [self.sideA_text,
+                                  self.sideB_text]
+        self.side_items_full = [self.side_e_text,
+                                self.sideA_text,
+                                self.sideB_text]
+        self.side_text_abbrev = " + ".join(item for item in self.side_items_abbrev if item)
+        self.side_text_full = " + ".join(item for item in self.side_items_full if item)
+        return self.side_text_abbrev, self.side_text_full
+
+    def reaction_text(self):
+        """Return the plain text for the process involved in a nepc cross section.
+        Parameters
+        ----------
+        cs : :class:`.CS` or :class:`.CustomCS`
+          A nepc cross section.
+        Returns
+        -------
+        : (str, str)
+            The plain text (abbrev, full) for the process involved in a NEPC cross section.
+        """
+        # FIXME: move this method to the CS Class
+        # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
+        # FIXME: decide how to represent total cross sections and implement
+        lhs_text_abbrev, lhs_text_full = self.reaction_text_side('LHS')
+        rhs_text_abbrev, rhs_text_full = self.reaction_text_side('RHS')
+        self.reaction_abbrev = " -> ".join([lhs_text_abbrev, rhs_text_abbrev])
+        self.reaction_full = " -> ".join([lhs_text_full, rhs_text_full])
+        return self.reaction_abbrev, self.reaction_full
+    
+    def reaction_latex_side(self, side):
+        """Return the LaTeX for the LHS of the process involved in a nepc cross section.
+        Parameters
+        ----------
+        side : str
+            'LHS' or 'RHS' to indicate which side of the reaction to return.
+        Returns
+        -------
+        : str
+            The LaTeX for the LHS of the process involved in a NEPC cross section.
+        """
+        # FIXME: move this method to the CS Class
+        # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
+        # FIXME: decide how to represent total cross sections and implement
+        keys = {'LHS': {'e': 'e_on_lhs',
+                        'sideA': 'lhsA_long',
+                        'sideB': 'lhsB_long',
+                        'side_v': 'lhs_v'},
+                'RHS': {'e': 'e_on_rhs',
+                        'sideA': 'rhsA_long',
+                        'sideB': 'rhsB_long',
+                        'side_v': 'rhs_v'}
+                }
+        self.e_on_side = self.metadata[keys[side]['e']]
+        # e_on_lhs = self.metadata['e_on_lhs']
+        if self.e_on_side == 0:
+            self.side_e_text= None
+        elif self.e_on_side == 1:
+            self.side_e_text = "e$^-$"
+        else:
+            self.side_e_text = str(self.e_on_side) + "e$^-$"
+
+        self.sideA_text = self.metadata[keys[side]['sideA']]
+        if self.metadata['process'] == 'excitation_v':
+            self.sideA_text = self.sideA_text.replace(")", " v=" + str(self.metadata[keys[side]['side_v']]) + ")")
+        self.sideB_text = self.metadata[keys[side]['sideB']]
+        self.side_items_full = [self.side_e_text,
+                                self.sideA_text,
+                                self.sideB_text]
+        self.side_text_full = " + ".join(item for item in self.side_items_full if item)
+
+        return self.side_text_full
+
+    def reaction_latex(self):
+        """Return the LaTeX for the process involved in a nepc cross section.
+        Parameters
+        ----------
+        cs : :class:`.CS` or :class:`.CustomCS`
+            A nepc cross section.
+        Returns
+        -------
+        : str
+            The LaTeX for the process involved in a NEPC cross section.
+        """
+        # FIXME: move this method to the CS Class
+        # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
+        # FIXME: decide how to represent total cross sections and implement
+        lhs_text = self.reaction_latex_side('LHS')
+        rhs_text = self.reaction_latex_side('RHS')
+        reaction = " $\\rightarrow$ ".join([lhs_text, rhs_text])
+        return reaction
 
     def plot(self, units_sigma=1E-20, plot_param_dict={'linewidth': 1},
              xlim_param_dict={'auto': True}, ylim_param_dict={'auto': True},
@@ -421,13 +561,11 @@ class CS:
             width of plot
         height: float, optional
             height of plot
-
         Returns
         -------
         :class:`matplotlib.axes.Axes`
             Plot of the cross section data, :attr:`.CS.data`, with formatting
             using information in the metadata, :attr:`.CS.metadata`.
-
         """
         _, axes = plt.subplots()
 
@@ -448,7 +586,7 @@ class CS:
         axes.tick_params(direction='in', which='both',
                          bottom=True, top=True, left=True, right=True)
 
-        reaction = reaction_latex(self)
+        reaction = self.reaction_latex
         label_items = [self.metadata['process'], ": ", reaction]
         label_text = " ".join(item for item in label_items if item)
         e_np = np.array(self.data['e'])
@@ -668,7 +806,7 @@ class Model:
                 max_peak_sigma = cs_peak_sigma
             if cs_peak_sigma < min_peak_sigma:
                 min_peak_sigma = cs_peak_sigma
-            reaction = reaction_latex(cs)
+            reaction = cs.reaction_latex()
             cs_lpu = cs.metadata["lpu"]
             cs_upu = cs.metadata["upu"]
             if cs_lpu is not None and cs_lpu > max_lpu:
@@ -933,176 +1071,3 @@ def process_attr(process: str, attr_list: List[str], test=False):
         process_attr_dict[attr] = proc_df.loc[proc_df.name==process, attr].values[0]
     
     return process_attr_dict
-                                         
-
-def reaction_latex_lhs(cs):
-    """Return the LaTeX for the LHS of the process involved in a nepc cross section.
-
-    Parameters
-    ----------
-    cs : :class:`.CS` or :class:`.CustomCS`
-        A nepc cross section.
-
-    Returns
-    -------
-    : str
-        The LaTeX for the LHS of the process involved in a NEPC cross section.
-
-    """
-    # FIXME: move this method to the CS Class
-    # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
-    # FIXME: decide how to represent total cross sections and implement
-    e_on_lhs = cs.metadata['e_on_lhs']
-    if e_on_lhs == 0:
-        lhs_e_text = None
-    elif e_on_lhs == 1:
-        lhs_e_text = "e$^-$"
-    else:
-        lhs_e_text = str(e_on_lhs) + "e$^-$"
-
-    lhsA_text = cs.metadata['lhsA_long']
-    if cs.metadata['process'] == 'excitation_v':
-        lhsA_text = lhsA_text.replace(")", " v=" + str(cs.metadata['lhs_v']) + ")")
-    lhsB_text = cs.metadata['lhsB_long']
-    lhs_items = [lhs_e_text,
-                 lhsA_text,
-                 lhsB_text]
-    lhs_text = " + ".join(item for item in lhs_items if item)
-
-    return lhs_text
-
-
-def reaction_latex_rhs(cs):
-    """Return the LaTeX for the RHS of the process involved in a nepc cross section.
-
-    Parameters
-    ----------
-    cs : :class:`.CS` or :class:`.CustomCS`
-        A nepc cross section.
-
-    Returns
-    -------
-    : str
-        The LaTeX for the RHS of the process involved in a NEPC cross section.
-
-    """
-    # FIXME: move this method to the CS Class
-    # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
-    # FIXME: decide how to represent total cross sections and implement
-    e_on_rhs = cs.metadata['e_on_rhs']
-    if e_on_rhs == 0:
-        rhs_e_text = None
-    elif e_on_rhs == 1:
-        rhs_e_text = "e$^-$"
-    else:
-        rhs_e_text = str(e_on_rhs) + "e$^-$"
-
-    rhsA_text = cs.metadata['rhsA_long']
-    if cs.metadata['process'] == 'excitation_v':
-        rhsA_text = rhsA_text.replace(")", " v=" + str(cs.metadata['rhs_v']) + ")")
-    rhsB_text = cs.metadata['rhsB_long']
-    rhs_items = [rhsA_text,
-                 rhsB_text,
-                 rhs_e_text]
-    rhs_text = " + ".join(item for item in rhs_items if item)
-
-    return rhs_text
-
-
-def reaction_latex(cs):
-    """Return the LaTeX for the process involved in a nepc cross section.
-
-    Parameters
-    ----------
-    cs : :class:`.CS` or :class:`.CustomCS`
-        A nepc cross section.
-
-    Returns
-    -------
-    : str
-        The LaTeX for the process involved in a NEPC cross section.
-
-    """
-    # FIXME: move this method to the CS Class
-    # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
-    # FIXME: decide how to represent total cross sections and implement
-    lhs_text = reaction_latex_lhs(cs)
-    rhs_text = reaction_latex_rhs(cs)
-    reaction = " $\\rightarrow$ ".join([lhs_text, rhs_text])
-    return reaction
-
-def reaction_text_side(side, cs):
-    """Return the plain text for the LHS or RHS of the process involved in a nepc cross section.
-
-    Parameters
-    ----------
-    side : str
-        'LHS' or 'RHS' to indicate which side of the reaction to return.
-
-    cs : :class:`.CS` or :class:`.CustomCS`
-        A nepc cross section.
-
-    Returns
-    -------
-    : str
-        The plain text for either the LHS or RHS of the process involved in a NEPC cross section.
-
-    """
-    # FIXME: move this method to the CS Class
-    # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
-    # FIXME: decide how to represent total cross sections and implement
-    keys = {'LHS': {'e': 'e_on_lhs',
-                    'sideA': 'lhsA',
-                    'sideB': 'lhsB',
-                    'side_v': 'lhs_v'},
-            'RHS': {'e': 'e_on_rhs',
-                    'sideA': 'rhsA',
-                    'sideB': 'rhsB',
-                    'side_v': 'rhs_v'}}
-
-    e_on_side = cs.metadata[keys[side]['e']]
-    if e_on_side == 0:
-        side_e_text = None
-    elif e_on_side == 1:
-        side_e_text = "E"
-    else:
-        side_e_text = str(e_on_side) + "E"
-
-    sideA_text = cs.metadata[keys[side]['sideA']]
-    if cs.metadata['process'] == 'excitation_v':
-        # TODO: modify for all interesting process types (e.g. excitation_j)
-        sideA_text = sideA_text.replace(")", " v=" + str(cs.metadata[keys[side]['side_v']]) + ")")
-    sideB_text = cs.metadata[keys[side]['sideB']]
-    side_items_abbrev = [sideA_text,
-                         sideB_text]
-    side_items_full = [side_e_text,
-                       sideA_text,
-                       sideB_text]
-    side_text_abbrev = " + ".join(item for item in side_items_abbrev if item)
-    side_text_full = " + ".join(item for item in side_items_full if item)
-
-    return side_text_abbrev, side_text_full
-
-
-def reaction_text(cs):
-    """Return the plain text for the process involved in a nepc cross section.
-
-    Parameters
-    ----------
-    cs : :class:`.CS` or :class:`.CustomCS`
-        A nepc cross section.
-
-    Returns
-    -------
-    : (str, str)
-        The plain text (abbrev, full) for the process involved in a NEPC cross section.
-
-    """
-    # FIXME: move this method to the CS Class
-    # FIXME: allow for varying electrons and including hv, v, j on rhs and lhs
-    # FIXME: decide how to represent total cross sections and implement
-    lhs_text_abbrev, lhs_text_full = reaction_text_side('LHS', cs)
-    rhs_text_abbrev, rhs_text_full = reaction_text_side('RHS', cs)
-    reaction_abbrev = " -> ".join([lhs_text_abbrev, rhs_text_abbrev])
-    reaction_full = " -> ".join([lhs_text_full, rhs_text_full])
-    return reaction_abbrev, reaction_full

--- a/nepc/util/parser.py
+++ b/nepc/util/parser.py
@@ -558,11 +558,11 @@ def format_model(model, type='lxcat', filename='lxcat.txt'):
                 if metadata == 'process':
                     line = f"{str(processes_lxcat[cs.metadata[metadata]]).upper()}\n" 
                 elif metadata == 'reaction_abbrev':
-                    line = f'{cs.reaction_text()[0]}\n'
+                    line = f'{cs.reaction_text[0]}\n'
                 elif metadata == 'threshold':
                     line = f" {threshold(cs):.6e}\n" 
                 elif metadata == 'reaction_full':
-                    line = (f'PROCESS: {str(cs.reaction_text()[1])}, '
+                    line = (f'PROCESS: {str(cs.reaction_text[1])}, '
                             f'{str(processes_lxcat[cs.metadata["process"]]).capitalize()}\n')
                 elif metadata == 'param':
                     if cs.metadata['process'] in ['total', 'elastic', 'elastic_total']:

--- a/nepc/util/parser.py
+++ b/nepc/util/parser.py
@@ -558,11 +558,11 @@ def format_model(model, type='lxcat', filename='lxcat.txt'):
                 if metadata == 'process':
                     line = f"{str(processes_lxcat[cs.metadata[metadata]]).upper()}\n" 
                 elif metadata == 'reaction_abbrev':
-                    line = f'{nepc.reaction_text(cs)[0]}\n'
+                    line = f'{cs.reaction_text()[0]}\n'
                 elif metadata == 'threshold':
                     line = f" {threshold(cs):.6e}\n" 
                 elif metadata == 'reaction_full':
-                    line = (f'PROCESS: {str(nepc.reaction_text(cs)[1])}, '
+                    line = (f'PROCESS: {str(cs.reaction_text()[1])}, '
                             f'{str(processes_lxcat[cs.metadata["process"]]).capitalize()}\n')
                 elif metadata == 'param':
                     if cs.metadata['process'] in ['total', 'elastic', 'elastic_total']:

--- a/tests/test_nepc.py
+++ b/tests/test_nepc.py
@@ -223,8 +223,8 @@ def test_reaction_latex(nepc_connect):
         lhsA_long = cs.metadata['lhsA_long']
         rhsA_long = cs.metadata['rhsA_long']
         if cs.metadata['process'] == 'excitation_v':
-            rhsA_long = rhsA_long.replace(")", " v=" + str(cs.metadata['rhs_v']) + ")")
             lhsA_long = lhsA_long.replace(")", " v=" + str(cs.metadata['lhs_v']) + ")")
+            rhsA_long = rhsA_long.replace(")", " v=" + str(cs.metadata['rhs_v']) + ")")
         assert isinstance(cs.reaction_latex(), str)
         assert cs.reaction_text_side('LHS', latex=True) \
                 == f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}e$^-$ + {lhsA_long}"
@@ -241,18 +241,23 @@ def test_reaction_text(nepc_connect):
     return strings representing the LHS, RHS, or full plain text
     for the reaction from a nepc cross section"""
     # TODO: sample all process types and enough permutations
-    cs = nepc.CS(nepc_connect[1], 1)
-    lhsA = 'N2(X1Sigmag+)'
-    rhsA = 'N2(X1Sigmag+)_jSCHULZ'
-    assert cs.reaction_text_side('LHS') == (lhsA, f'E + {lhsA}')
-    assert cs.reaction_text_side('RHS') == (rhsA, f'E + {rhsA}')
-    assert cs.reaction_text() == (f'{lhsA} -> {rhsA}',
-                                  f'E + {lhsA} -> E + {rhsA}')
-    lhsA_long = 'N${}_2$ (X ${}^1\\Sigma_g^+$)'
-    rhsA_long = 'N${}_2$ (X ${}^1\\Sigma_g^+ j=SCHULZ$)'
-    assert cs.reaction_text_side('LHS', latex=True) == f'e$^-$ + {lhsA_long}'
-    assert cs.reaction_text_side('RHS', latex=True) == f'e$^-$ + {rhsA_long}'
-    assert cs.reaction_latex() == f'e$^-$ + {lhsA_long} $\\rightarrow$ e$^-$ + {rhsA_long}'
+    for i in range(1, 30):
+        cs = nepc.CS(nepc_connect[1], i)
+        lhsA = cs.metadata['lhsA']
+        rhsA = cs.metadata['rhsA']
+        if cs.metadata['process'] == 'excitation_v':
+            lhsA = lhsA.replace(")", " v=" + str(cs.metadata['lhs_v']) + ")")
+            rhsA = rhsA.replace(")", " v=" + str(cs.metadata['rhs_v']) + ")")
+        assert isinstance(cs.reaction_latex(), str)
+        assert cs.reaction_text_side('LHS') \
+                == (lhsA, f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}E + {lhsA}")
+        assert cs.reaction_text_side('RHS') \
+                == (rhsA, f"{cs.metadata['e_on_rhs']if cs.metadata['e_on_rhs'] > 1 else ''}E + {rhsA}")
+        assert cs.reaction_text() == (f"{lhsA} -> {rhsA}", 
+                                      f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}" + \
+                                      f"E + {lhsA} -> " + \
+                                      f"{cs.metadata['e_on_rhs']if cs.metadata['e_on_rhs'] > 1 else ''}" + \
+                                      f"E + {rhsA}")
 
 
 @pytest.mark.usefixtures("nepc_connect")

--- a/tests/test_nepc.py
+++ b/tests/test_nepc.py
@@ -225,12 +225,12 @@ def test_reaction_latex(nepc_connect):
         if cs.metadata['process'] == 'excitation_v':
             lhsA_long = lhsA_long.replace(")", " v=" + str(cs.metadata['lhs_v']) + ")")
             rhsA_long = rhsA_long.replace(")", " v=" + str(cs.metadata['rhs_v']) + ")")
-        assert isinstance(cs.reaction_latex(), str)
+        assert isinstance(cs.reaction_latex, str)
         assert cs.reaction_text_side('LHS', latex=True) \
                 == f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}e$^-$ + {lhsA_long}"
         assert cs.reaction_text_side('RHS', latex=True) \
                 == f"{cs.metadata['e_on_rhs']if cs.metadata['e_on_rhs'] > 1 else ''}e$^-$ + {rhsA_long}"
-        assert cs.reaction_latex() == f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}" + \
+        assert cs.reaction_latex == f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}" + \
                                       f"e$^-$ + {lhsA_long} $\\rightarrow$ " + \
                                       f"{cs.metadata['e_on_rhs']if cs.metadata['e_on_rhs'] > 1 else ''}" + \
                                       f"e$^-$ + {rhsA_long}"
@@ -248,12 +248,12 @@ def test_reaction_text(nepc_connect):
         if cs.metadata['process'] == 'excitation_v':
             lhsA = lhsA.replace(")", " v=" + str(cs.metadata['lhs_v']) + ")")
             rhsA = rhsA.replace(")", " v=" + str(cs.metadata['rhs_v']) + ")")
-        assert isinstance(cs.reaction_latex(), str)
+        assert isinstance(cs.reaction_latex, str)
         assert cs.reaction_text_side('LHS') \
                 == (lhsA, f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}E + {lhsA}")
         assert cs.reaction_text_side('RHS') \
                 == (rhsA, f"{cs.metadata['e_on_rhs']if cs.metadata['e_on_rhs'] > 1 else ''}E + {rhsA}")
-        assert cs.reaction_text() == (f"{lhsA} -> {rhsA}", 
+        assert cs.reaction_text == (f"{lhsA} -> {rhsA}", 
                                       f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}" + \
                                       f"E + {lhsA} -> " + \
                                       f"{cs.metadata['e_on_rhs']if cs.metadata['e_on_rhs'] > 1 else ''}" + \

--- a/tests/test_nepc.py
+++ b/tests/test_nepc.py
@@ -1,5 +1,6 @@
 """Tests for nepc/nepc.py"""
 import pandas as pd
+from nepc.nepc import cs_e
 import pytest
 import mysql.connector
 import nepc
@@ -219,7 +220,7 @@ def test_reaction_latex(nepc_connect):
     # FIXME: randomly sample cross sections
     for i in range(1, 30):
         cs = nepc.CS(nepc_connect[1], i)
-        assert isinstance(nepc.reaction_latex(cs), str)
+        assert isinstance(cs.reaction_latex(), str)
 
 @pytest.mark.usefixtures("nepc_connect")
 def test_reaction_text(nepc_connect):
@@ -230,10 +231,10 @@ def test_reaction_text(nepc_connect):
     cs = nepc.CS(nepc_connect[1], 1)
     lhsA = 'N2(X1Sigmag+)'
     rhsA = 'N2(X1Sigmag+)_jSCHULZ'
-    assert nepc.reaction_text_side('LHS', cs) == (lhsA, f'E + {lhsA}')
-    assert nepc.reaction_text_side('RHS', cs) == (rhsA, f'E + {rhsA}')
-    assert nepc.reaction_text(cs) == (f'{lhsA} -> {rhsA}',
-                                      f'E + {lhsA} -> E + {rhsA}')
+    assert cs.reaction_text_side('LHS') == (lhsA, f'E + {lhsA}')
+    assert cs.reaction_text_side('RHS') == (rhsA, f'E + {rhsA}')
+    assert cs.reaction_text() == (f'{lhsA} -> {rhsA}',
+                                  f'E + {lhsA} -> E + {rhsA}')
 
 
 @pytest.mark.usefixtures("nepc_connect")

--- a/tests/test_nepc.py
+++ b/tests/test_nepc.py
@@ -220,7 +220,20 @@ def test_reaction_latex(nepc_connect):
     # FIXME: randomly sample cross sections
     for i in range(1, 30):
         cs = nepc.CS(nepc_connect[1], i)
+        lhsA_long = cs.metadata['lhsA_long']
+        rhsA_long = cs.metadata['rhsA_long']
+        if cs.metadata['process'] == 'excitation_v':
+            rhsA_long = rhsA_long.replace(")", " v=" + str(cs.metadata['rhs_v']) + ")")
+            lhsA_long = lhsA_long.replace(")", " v=" + str(cs.metadata['lhs_v']) + ")")
         assert isinstance(cs.reaction_latex(), str)
+        assert cs.reaction_text_side('LHS', latex=True) \
+                == f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}e$^-$ + {lhsA_long}"
+        assert cs.reaction_text_side('RHS', latex=True) \
+                == f"{cs.metadata['e_on_rhs']if cs.metadata['e_on_rhs'] > 1 else ''}e$^-$ + {rhsA_long}"
+        assert cs.reaction_latex() == f"{cs.metadata['e_on_lhs']if cs.metadata['e_on_lhs'] > 1 else ''}" + \
+                                      f"e$^-$ + {lhsA_long} $\\rightarrow$ " + \
+                                      f"{cs.metadata['e_on_rhs']if cs.metadata['e_on_rhs'] > 1 else ''}" + \
+                                      f"e$^-$ + {rhsA_long}"
 
 @pytest.mark.usefixtures("nepc_connect")
 def test_reaction_text(nepc_connect):

--- a/tests/test_nepc.py
+++ b/tests/test_nepc.py
@@ -235,6 +235,11 @@ def test_reaction_text(nepc_connect):
     assert cs.reaction_text_side('RHS') == (rhsA, f'E + {rhsA}')
     assert cs.reaction_text() == (f'{lhsA} -> {rhsA}',
                                   f'E + {lhsA} -> E + {rhsA}')
+    lhsA_long = 'N${}_2$ (X ${}^1\\Sigma_g^+$)'
+    rhsA_long = 'N${}_2$ (X ${}^1\\Sigma_g^+ j=SCHULZ$)'
+    assert cs.reaction_text_side('LHS', latex=True) == f'e$^-$ + {lhsA_long}'
+    assert cs.reaction_text_side('RHS', latex=True) == f'e$^-$ + {rhsA_long}'
+    assert cs.reaction_latex() == f'e$^-$ + {lhsA_long} $\\rightarrow$ e$^-$ + {rhsA_long}'
 
 
 @pytest.mark.usefixtures("nepc_connect")


### PR DESCRIPTION
This pull request tackles moving reaction_latex function inside the CS class #24. I used a lot of what Nancy had wrote before, but I finished adding `reaction_latex` to the CS class. I also changed the function calls from the test files and from the `__init__.py` files. 

Right now `reaction_text_side` and `reaction_latex_side` are very similar, so I was thinking about working on a way to combine those two too, so we only have one function that both `reaction_latex` and `reaction_text` can call 